### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# BXCodeScanner
+# BXcodeScanner
 
-[![CI Status](http://img.shields.io/travis/banxi1988/BXCodeScanner.svg?style=flat)](https://travis-ci.org/banxi1988/BXCodeScanner)
-[![Version](https://img.shields.io/cocoapods/v/BXCodeScanner.svg?style=flat)](http://cocoapods.org/pods/BXCodeScanner)
-[![License](https://img.shields.io/cocoapods/l/BXCodeScanner.svg?style=flat)](http://cocoapods.org/pods/BXCodeScanner)
-[![Platform](https://img.shields.io/cocoapods/p/BXCodeScanner.svg?style=flat)](http://cocoapods.org/pods/BXCodeScanner)
+[![CI Status](http://img.shields.io/travis/banxi1988/BXcodeScanner.svg?style=flat)](https://travis-ci.org/banxi1988/BXcodeScanner)
+[![Version](https://img.shields.io/cocoapods/v/BXcodeScanner.svg?style=flat)](http://cocoapods.org/pods/BXcodeScanner)
+[![License](https://img.shields.io/cocoapods/l/BXcodeScanner.svg?style=flat)](http://cocoapods.org/pods/BXcodeScanner)
+[![Platform](https://img.shields.io/cocoapods/p/BXcodeScanner.svg?style=flat)](http://cocoapods.org/pods/BXcodeScanner)
 
 ## Usage
 
@@ -13,11 +13,11 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
-BXCodeScanner is available through [CocoaPods](http://cocoapods.org). To install
+BXcodeScanner is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod "BXCodeScanner"
+pod "BXcodeScanner"
 ```
 
 ## Author
@@ -26,4 +26,4 @@ banxi1988, banxi1988@gmail.com
 
 ## License
 
-BXCodeScanner is available under the MIT license. See the LICENSE file for more info.
+BXcodeScanner is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
